### PR TITLE
feat: Implement Admin Panel for Menu Management

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin - Menu Management</title>
+    <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;700;800&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+    <link rel="stylesheet" href="style.css">
+    <script type="module" src="src/app.js" defer></script>
+</head>
+<body class="bg-secondary-color text-text-primary">
+
+    <div id="main-header"></div>
+
+    <main id="admin-management" class="container mx-auto px-8 lg:px-16 py-12">
+        <h1 class="text-4xl font-bold text-white mb-8">Menu Management</h1>
+
+        <!-- Add/Edit Form -->
+        <div class="bg-[#1C1C1C] p-8 rounded-lg mb-12">
+            <h2 class="text-2xl font-bold text-white mb-6" id="form-title">Add New Menu Item</h2>
+            <form id="menu-item-form" class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <input type="hidden" id="item-id">
+                <div>
+                    <label for="item-name" class="block text-sm font-medium text-gray-300 mb-2">Name</label>
+                    <input type="text" id="item-name" name="name" class="w-full bg-gray-800 border-gray-700 text-white rounded-md" required>
+                </div>
+                <div>
+                    <label for="item-price" class="block text-sm font-medium text-gray-300 mb-2">Price</label>
+                    <input type="number" id="item-price" name="price" class="w-full bg-gray-800 border-gray-700 text-white rounded-md" required step="0.01">
+                </div>
+                <div class="md:col-span-2">
+                    <label for="item-description" class="block text-sm font-medium text-gray-300 mb-2">Description</label>
+                    <textarea id="item-description" name="description" rows="3" class="w-full bg-gray-800 border-gray-700 text-white rounded-md"></textarea>
+                </div>
+                <div>
+                    <label for="item-category" class="block text-sm font-medium text-gray-300 mb-2">Category</label>
+                    <input type="text" id="item-category" name="category" class="w-full bg-gray-800 border-gray-700 text-white rounded-md" required>
+                </div>
+                <div>
+                    <label for="item-subCategory" class="block text-sm font-medium text-gray-300 mb-2">Sub-Category</label>
+                    <input type="text" id="item-subCategory" name="subCategory" class="w-full bg-gray-800 border-gray-700 text-white rounded-md" required>
+                </div>
+                <div class="md:col-span-2">
+                    <label for="item-image" class="block text-sm font-medium text-gray-300 mb-2">Image URL</label>
+                    <input type="url" id="item-image" name="image" class="w-full bg-gray-800 border-gray-700 text-white rounded-md">
+                </div>
+                <div class="md:col-span-2 flex justify-end gap-4">
+                    <button type="button" id="cancel-edit-btn" class="bg-gray-600 text-white rounded-full h-12 px-8 font-bold hidden">Cancel</button>
+                    <button type="submit" class="bg-[var(--primary-color)] text-black rounded-full h-12 px-8 font-bold">Save Item</button>
+                </div>
+            </form>
+        </div>
+
+        <!-- Menu Items Table -->
+        <div class="bg-[#1C1C1C] p-8 rounded-lg">
+            <h2 class="text-2xl font-bold text-white mb-6">Current Menu</h2>
+            <div class="overflow-x-auto">
+                <table class="min-w-full text-sm text-left text-gray-400">
+                    <thead class="text-xs text-gray-300 uppercase bg-gray-700">
+                        <tr>
+                            <th scope="col" class="px-6 py-3">Name</th>
+                            <th scope="col" class="px-6 py-3">Price</th>
+                            <th scope="col" class="px-6 py-3">Category</th>
+                            <th scope="col" class="px-6 py-3">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="menu-items-table-body">
+                        <!-- Rows will be injected by JavaScript -->
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </main>
+
+    <div id="main-footer"></div>
+
+</body>
+</html>

--- a/footer.html
+++ b/footer.html
@@ -14,6 +14,7 @@
             <a class="text-base font-medium text-gray-300 hover:text-white transition-colors duration-300" href="about-us.html">About</a>
             <a class="text-base font-medium text-gray-300 hover:text-white transition-colors duration-300" href="gift-vouchers.html">Gift Vouchers</a>
             <a class="text-base font-medium text-gray-300 hover:text-white transition-colors duration-300" href="get-in-touch.html">Contact</a>
+            <a class="text-base font-medium text-gray-300 hover:text-white transition-colors duration-300" href="admin.html">Admin</a>
         </nav>
         <div class="flex gap-6">
             <a href="https://twitter.com/aviaip" target="_blank" rel="noopener noreferrer" class="text-gray-400 hover:text-white transition-colors" aria-label="Twitter"><svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M22.46 6c-.77.35-1.6.58-2.46.67.88-.53 1.56-1.37 1.88-2.38-.83.5-1.75.85-2.72 1.05C18.37 4.5 17.26 4 16 4c-2.35 0-4.27 1.92-4.27 4.27 0 .34.04.67.11.98-3.56-.18-6.73-1.89-8.84-4.48-.37.63-.58 1.37-.58 2.15 0 1.48.75 2.79 1.9 3.55-.7-.02-1.37-.22-1.95-.5v.03c0 2.07 1.48 3.8 3.44 4.2-.36.1-.74.15-1.13.15-.28 0-.55-.03-.81-.08.54 1.69 2.1 2.93 3.96 2.96-1.46 1.14-3.3 1.82-5.3 1.82-.34 0-.68-.02-1.02-.06 1.9 1.22 4.16 1.93 6.56 1.93 7.88 0 12.2-6.52 12.2-12.2 0-.19 0-.37-.01-.56.84-.6 1.56-1.36 2.14-2.22z"></path></svg></a>

--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 import { loadHeader, loadFooter } from './components.js';
 import { initMenuPage } from './pages/menu.js';
 import { initOrderPage } from './pages/order.js';
+import { initAdminPage } from './pages/admin.js';
 
 function initializeMobileMenu() {
     const mobileMenuButton = document.getElementById('mobile-menu-button');
@@ -96,6 +97,9 @@ async function initApp() {
     }
     if (path.endsWith('order-page.html')) {
         initOrderPage();
+    }
+    if (path.endsWith('admin.html')) {
+        initAdminPage();
     }
 }
 

--- a/src/pages/admin.js
+++ b/src/pages/admin.js
@@ -1,0 +1,122 @@
+import { store } from '../store.js';
+
+let menuItems = [];
+
+const form = {
+    title: document.getElementById('form-title'),
+    form: document.getElementById('menu-item-form'),
+    id: document.getElementById('item-id'),
+    name: document.getElementById('item-name'),
+    price: document.getElementById('item-price'),
+    description: document.getElementById('item-description'),
+    category: document.getElementById('item-category'),
+    subCategory: document.getElementById('item-subCategory'),
+    image: document.getElementById('item-image'),
+    cancelBtn: document.getElementById('cancel-edit-btn'),
+    submitBtn: document.querySelector('#menu-item-form button[type="submit"]')
+};
+
+const tableBody = document.getElementById('menu-items-table-body');
+
+function renderTable() {
+    if (!tableBody) return;
+    tableBody.innerHTML = '';
+
+    menuItems.forEach(item => {
+        const row = document.createElement('tr');
+        row.className = 'bg-gray-800 border-b border-gray-700';
+        row.innerHTML = `
+            <td class="px-6 py-4 font-medium text-white">${item.name}</td>
+            <td class="px-6 py-4">$${item.price.toFixed(2)}</td>
+            <td class="px-6 py-4">${item.category} / ${item.subCategory}</td>
+            <td class="px-6 py-4 flex gap-4">
+                <button class="font-medium text-blue-500 hover:underline edit-btn" data-id="${item.id}">Edit</button>
+                <button class="font-medium text-red-500 hover:underline delete-btn" data-id="${item.id}">Delete</button>
+            </td>
+        `;
+        tableBody.appendChild(row);
+    });
+}
+
+function resetForm() {
+    form.title.textContent = 'Add New Menu Item';
+    form.form.reset();
+    form.id.value = '';
+    form.cancelBtn.classList.add('hidden');
+    form.submitBtn.textContent = 'Save Item';
+}
+
+function populateForm(itemId) {
+    const item = menuItems.find(i => i.id == itemId);
+    if (!item) return;
+
+    form.title.textContent = `Editing: ${item.name}`;
+    form.id.value = item.id;
+    form.name.value = item.name;
+    form.price.value = item.price;
+    form.description.value = item.description;
+    form.category.value = item.category;
+    form.subCategory.value = item.subCategory;
+    form.image.value = item.image;
+
+    form.cancelBtn.classList.remove('hidden');
+    form.submitBtn.textContent = 'Update Item';
+    window.scrollTo(0, 0);
+}
+
+async function handleFormSubmit(event) {
+    event.preventDefault();
+    const formData = new FormData(form.form);
+    const itemId = form.id.value;
+
+    const newMenuItemData = {
+        id: itemId ? parseInt(itemId) : Date.now(), // Create a new ID if it's a new item
+        name: formData.get('name'),
+        price: parseFloat(formData.get('price')),
+        description: formData.get('description'),
+        category: [formData.get('category')],
+        subCategory: formData.get('subCategory'),
+        image: formData.get('image') || 'https://via.placeholder.com/150'
+    };
+
+    if (itemId) {
+        // This is an update
+        await store.updateMenuItem(newMenuItemData);
+    } else {
+        // This is a new item
+        await store.addMenuItem(newMenuItemData);
+    }
+
+    menuItems = await store.getMenu(true); // Force refresh from storage
+    renderTable();
+    resetForm();
+}
+
+async function handleDeleteClick(event) {
+    if (!event.target.classList.contains('delete-btn')) return;
+
+    const itemId = event.target.dataset.id;
+    if (confirm('Are you sure you want to delete this item?')) {
+        await store.deleteMenuItem(parseInt(itemId));
+        menuItems = await store.getMenu(true); // Force refresh from storage
+        renderTable();
+    }
+}
+
+function handleEditClick(event) {
+    if (!event.target.classList.contains('edit-btn')) return;
+    const itemId = event.target.dataset.id;
+    populateForm(itemId);
+}
+
+export async function initAdminPage() {
+    if (!document.getElementById('admin-management')) return;
+
+    menuItems = await store.getMenu();
+    renderTable();
+
+    form.form.addEventListener('submit', handleFormSubmit);
+    tableBody.addEventListener('click', handleDeleteClick);
+    tableBody.addEventListener('click', handleEditClick);
+    form.cancelBtn.addEventListener('click', resetForm);
+}

--- a/src/store.js
+++ b/src/store.js
@@ -5,29 +5,74 @@ const state = {
     order: []
 };
 
-let menuFetched = false;
+const MENU_STORAGE_KEY = 'restaurantMenu';
+
+// Function to save menu to localStorage
+function saveMenuToStorage() {
+    localStorage.setItem(MENU_STORAGE_KEY, JSON.stringify(state.menu));
+}
+
+// Function to load menu from localStorage
+function loadMenuFromStorage() {
+    const menuFromStorage = localStorage.getItem(MENU_STORAGE_KEY);
+    if (menuFromStorage) {
+        state.menu = JSON.parse(menuFromStorage);
+        return true;
+    }
+    return false;
+}
 
 export const store = {
-    getMenu: async () => {
-        if (!menuFetched) {
-            try {
-                const response = await fetch(config.api.menuUrl);
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
-                state.menu = await response.json();
-                menuFetched = true;
-            } catch (error) {
-                console.error("Could not fetch menu:", error);
-                return []; // Return empty array on error
+    getMenu: async (forceRefresh = false) => {
+        if (!forceRefresh && state.menu.length > 0) {
+            return state.menu;
+        }
+
+        if (!forceRefresh && loadMenuFromStorage()) {
+            return state.menu;
+        }
+
+        try {
+            const response = await fetch(config.api.menuUrl);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            state.menu = await response.json();
+            saveMenuToStorage();
+        } catch (error) {
+            console.error("Could not fetch menu:", error);
+            // If fetch fails, try to load from storage as a fallback
+            if (!loadMenuFromStorage()) {
+                return []; // Return empty if nothing in storage either
             }
         }
         return state.menu;
     },
+
+    addMenuItem: async (item) => {
+        state.menu.push(item);
+        saveMenuToStorage();
+    },
+
+    updateMenuItem: async (updatedItem) => {
+        const index = state.menu.findIndex(item => item.id === updatedItem.id);
+        if (index !== -1) {
+            state.menu[index] = updatedItem;
+            saveMenuToStorage();
+        }
+    },
+
+    deleteMenuItem: async (itemId) => {
+        state.menu = state.menu.filter(item => item.id !== itemId);
+        saveMenuToStorage();
+    },
+
     getOrder: () => {
         return state.order;
     },
+
     addToOrder: (item) => {
         state.order.push(item);
+        // Note: Order persistence is not implemented in this step
     }
 };


### PR DESCRIPTION
Adds a new /admin.html page to allow for the management of menu items. Includes functionality to create, read, update, and delete menu items from a user-friendly interface. Introduces localStorage persistence in src/store.js to fake a backend, allowing changes to be saved across sessions. Adds a link to the new admin page in the footer for easy access.